### PR TITLE
Added startgame script to eventsystem, fix upgrade

### DIFF
--- a/Assets/Scenes/StartMenu.unity
+++ b/Assets/Scenes/StartMenu.unity
@@ -499,6 +499,7 @@ GameObject:
   - component: {fileID: 438481606}
   - component: {fileID: 438481605}
   - component: {fileID: 438481604}
+  - component: {fileID: 438481607}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -554,6 +555,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &438481607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 438481603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4a96f63f8c86b14daaf8df6d413758b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &468139931
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This makes it so when the player starts the game naturally, they have no upgrades and things work correctly.